### PR TITLE
feature: allow for custom host attribute when building pgpass

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,12 @@ This table lists the tested version of OS/Barman couples.
 barman_databases:                                 # Mandatory
   - name: 'app1'                                     # Mandatory
     description: 'Database of App1'                  # Mandatory
-    primary_host: 10.0.0.1                           # Mandatory
+    primary_host: "{{ groups['db-app1'][0] }}"       # Mandatory
     postgres_barman_password: 'super_secure_vaulted' # Mandatory
     backup_method: rsync                             # Optional (default value)
-    ansible_group: "db-app1"                         # Optional (used to authorize SSH access)
     retention_policy: 'RECOVERY WINDOW OF 7 DAYS'    # Optional (default value)
+    standby_hosts: "{{ groups['db-app1'][1:] }}"     # Optional (Automatically authorize SSH this servers list)
+    extract_host_from_var: 'ec2_private_ip_address'  # Optional (host variable to extract from inventory hostvars)
 
 barman_restore_directory: "/home/restore-$server"
 

--- a/tasks/authorize.yml
+++ b/tasks/authorize.yml
@@ -4,7 +4,7 @@
     user: "postgres"
     key: "{{ backup_server_pub_key['content']|b64decode }}"
     state: present
-  delegate_to: "{{ hostvars[item].ansible_host | default(item) }}"
+  delegate_to: "{{ item }}"
   with_items: "{{ groups[barman_database.ansible_group] }}"
   ignore_errors: True
 

--- a/tasks/authorize.yml
+++ b/tasks/authorize.yml
@@ -1,11 +1,21 @@
 ---
+- set_fact:
+    standby_hosts: "{{ barman_database.standby_hosts|default([]) }}"
+
+- set_fact:
+    all_hosts: "{{ [barman_database.primary_host] + standby_hosts }}"
+
+- set_fact:
+    all_hosts_hostname: "{{ all_hosts | map('extract', hostvars, barman_database.extract_host_from_var) | list }}"
+  when: barman_database.extract_host_from_var is defined
+
 - name: Authorize SSH access to SQL servers
   authorized_key:
     user: "postgres"
     key: "{{ backup_server_pub_key['content']|b64decode }}"
     state: present
   delegate_to: "{{ item }}"
-  with_items: "{{ groups[barman_database.ansible_group] }}"
+  with_items: "{{ all_hosts }}"
   ignore_errors: True
 
 - name: Configure credentials for PSQL access to servers
@@ -16,5 +26,5 @@
     group: barman
     owner: barman
     mode: 0600
-    line: "{{ hostvars[item].ansible_host | default(item) }}:{{ barman_database.primary_port|default(5432) }}:*:barman:{{ barman_database.postgres_barman_password }}"
-  with_items: "{{ groups[barman_database.ansible_group] }}"
+    line: "{{ item }}:{{ barman_database.primary_port|default(5432) }}:*:barman:{{ barman_database.postgres_barman_password }}"
+  with_items: "{{ all_hosts_hostname|default(all_hosts) }}"

--- a/tasks/barman.yml
+++ b/tasks/barman.yml
@@ -56,7 +56,6 @@
   with_items: "{{ barman_databases }}"
   loop_control:
     loop_var: barman_database
-  when: barman_database.ansible_group is defined
 
 - name: Create WAL streaming replication slots if needed
   include: streaming.yml

--- a/templates/barman.conf.j2
+++ b/templates/barman.conf.j2
@@ -102,11 +102,16 @@ archiver = on
 ;minimum_redundancy = 1
 
 {% for database in barman_databases %}
+{% if database.extract_host_from_var is defined -%}
+{% set primary_host_name = hostvars[database.primary_host][database.extract_host_from_var] %}
+{%- else %}
+{% set primary_host_name = database.primary_host %}
+{%- endif %}
 [{{ database.name }}]
 description = "{{ database.description }}"
-ssh_command = ssh postgres@{{ database.primary_host }}
+ssh_command = ssh postgres@{{ primary_host_name }}
 backup_method = {{ database.backup_method|default('rsync') }}
-conninfo = host={{ database.primary_host }}
+conninfo = host={{ primary_host_name }}
  {%- if database.primary_port is defined %} port={{ database.primary_port }}{% endif %}
  user=barman dbname=postgres
 {% if database.backup_method|default('rsync') == 'postgres' %}
@@ -116,7 +121,7 @@ conninfo = host={{ database.primary_host }}
 streaming_archiver = on
 slot_name = barman
 {% endif %}
-streaming_conninfo = host={{ database.primary_host }}
+streaming_conninfo = host={{ primary_host_name }}
  {%- if database.primary_port is defined %} port={{ database.primary_port }}{% endif %}
  user=barman dbname=postgres
 {% endif %}


### PR DESCRIPTION
This PR adds the ability to change the default `ansible_host` attribute used to build the PGpass file on the barman server.

It also delegates to Ansible's known host name without the need to fetch the `ansible_host` variable from the host.