### PR TITLE
rsync: don't make rsync daemon mandatory

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ barman_databases:                                 # Mandatory
 
 barman_restore_directory: "/home/restore-$server"
 
-# If Rsync backup method is used (default)
+barman_rsync_daemon_enabled: true (default to false)
+# If Rsync daemon is enabled
 barman_rsync_allowed_hosts: 10.0.0.0/24
 barman_rsync_password: "vaulted_secret_password"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,3 +2,4 @@
 barman_restore_directory: '/home/restore-$server'
 barman_config: {}
 barman_cron_enabled: True
+barman_rsync_daemon_enabled: false

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: restart rsync daemon
+  service:
+    name: rsync
+    state: restarted

--- a/tasks/barman.yml
+++ b/tasks/barman.yml
@@ -34,10 +34,19 @@
 
 - name: Copy rsyncd.conf file
   template: src=rsyncd.conf.j2 dest=/etc/rsyncd.conf mode=0600
+  notify: restart rsync daemon
+  when: barman_rsync_daemon_enabled
 
 - name: Copy rsync.secrets
   template: src=rsyncd.secrets.j2 dest=/etc/rsyncd.secrets mode=0400
   no_log: True
+  when: barman_rsync_daemon_enabled
+
+- name: Start rsync daemon
+  service:
+    name: rsync
+    state: started
+  when: barman_rsync_daemon_enabled
 
 - name: Create SSH key for barman user
   user:


### PR DESCRIPTION
Backup method via rsync uses SSH by default. A rsync daemon is not mandatory to have working backups if an ssh connection is available between the barman server and the sql servers.

This PR makes the rsync daemon optional behind the `barman_rsync_daemon_enabled` host variable.