### PR TITLE
config(backup_option): warning introduced in barman 2.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ barman_config:                        # Optional
   bandwith_limit: 0
   parallel_jobs: 2
   network_compression: true|false
+  backup_options: exclusive_backup|concurrent_backup
 ```
 
 #### Testing

--- a/templates/barman.conf.j2
+++ b/templates/barman.conf.j2
@@ -75,7 +75,11 @@ network_compression = {{ barman_config['network_compression'] }}
 
 ; Identify the standard behavior for backup operations: possible values are
 ; exclusive_backup (default), concurrent_backup
+{% if barman_config['backup_options'] is defined -%}
+backup_options = {{ barman_config['backup_options'] }}
+{% else %}
 ;backup_options = exclusive_backup
+{% endif %}
 
 ; Number of retries of data copy during base backup after an error - default 0
 ;basebackup_retry_times = 0


### PR DESCRIPTION
This commit offers to possibility to configure the `backup_options`
from barman configuation.

Since Barman 2.8
https://github.com/2ndquadrant-it/barman/blob/master/ChangeLog#L29
a warning is displayed if that configuration line is not set when
using `rsync` backup_method.